### PR TITLE
Fixed rake list_db_servers and rake update_db_server[<server_name>]

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -80,14 +80,16 @@ task :list_db_servers => :rake_dot_net_initialize do
   puts "scanning the network for db servers (this may take a while)"
   puts "if you already know what database server you want to connect to,"
   puts "you can change your connection strings in the application by running the command:"
-  puts "rake update_db_server[server_name], example: rake update_db_server[.\\sqlexpress]"
+  puts "rake update_db_server[server_name], example: rake update_db_server[\'.\\sqlexpress\']"
   puts "looking....\n\n"
 
   output = `sqlcmd -Lc`
   puts "here are your db servers and the rake command to update your connection strings:\n\n"
   output.each_line do |line|
-    puts "rake update_db_server[#{line.strip}]" if line.strip != ""
+    puts "rake update_db_server[\'#{line.strip}\']" if line.strip != ""
   end
+
+  puts "\nRun the command exactly as it is displayed above, including single quotes around the server name"
 end
 
 desc "updates all database connection string server values to the value specified, example: rake update_db_server[./sqlexpress]"
@@ -97,11 +99,13 @@ task :update_db_server, [:new_value] => :rake_dot_net_initialize do |t, args|
   [
     "Oak.Tests/App.config"
   ].each do |file|
-    puts "updating connection string in: #{ file }"
-    content = File.open(file).read
-    content.gsub!("Data Source=#{ @database_server };", "Data Source=#{ args[:new_value] };")
-    File.open(file, "w") { |f| f.write(content) }
-    puts "done"
+    if File.exist? file
+      puts "updating connection string in: #{ file }"
+      content = File.open(file).read
+      content.gsub!("Data Source=#{ @database_server };", "Data Source=#{ args[:new_value] };")
+      File.open(file, "w") { |f| f.write(content) }
+      puts "done"
+    end
   end
 
   puts "updating dev.yml"

--- a/Sample Apps/BattleShip/Rakefile.rb
+++ b/Sample Apps/BattleShip/Rakefile.rb
@@ -138,14 +138,16 @@ task :list_db_servers => :rake_dot_net_initialize do
   puts "scanning the network for db servers (this may take a while)"
   puts "if you already know what database server you want to connect to,"
   puts "you can change your connection strings in the application by running the command:"
-  puts "rake update_db_server[server_name], example: rake update_db_server[.\\sqlexpress]"
+  puts "rake update_db_server[server_name], example: rake update_db_server[\'.\\sqlexpress\']"
   puts "looking....\n\n"
 
   output = `sqlcmd -Lc`
   puts "here are your db servers and the rake command to update your connection strings:\n\n"
   output.each_line do |line|
-    puts "rake update_db_server[#{line.strip}]" if line.strip != ""
+    puts "rake update_db_server[\'#{line.strip}\']" if line.strip != ""
   end
+
+  puts "\nRun the command exactly as it is displayed above, including single quotes around the server name"
 end
 
 desc "updates all database connection string server values to the value specified, example: rake update_db_server[./sqlexpress]"
@@ -156,11 +158,13 @@ task :update_db_server, [:new_value] => :rake_dot_net_initialize do |t, args|
     "#{ @mvc_project_directory }/Web.config",
     "#{ @test_project }/App.config"
   ].each do |file|
-    puts "updating connection string in: #{ file }"
-    content = File.open(file).read
-    content.gsub!("data source=#{ @database_server };", "data source=#{ args[:new_value] };")
-    File.open(file, "w") { |f| f.write(content) }
-    puts "done"
+    if File.exist? file
+      puts "updating connection string in: #{ file }"
+      content = File.open(file).read
+      content.gsub!("data source=#{ @database_server };", "data source=#{ args[:new_value] };")
+      File.open(file, "w") { |f| f.write(content) }
+      puts "done"
+    end
   end
 
   puts "updating dev.yml"

--- a/Sample Apps/BorrowedGames/Rakefile.rb
+++ b/Sample Apps/BorrowedGames/Rakefile.rb
@@ -211,14 +211,16 @@ task :list_db_servers => :rake_dot_net_initialize do
   puts "scanning the network for db servers (this may take a while)"
   puts "if you already know what database server you want to connect to,"
   puts "you can change your connection strings in the application by running the command:"
-  puts "rake update_db_server[server_name], example: rake update_db_server[.\\sqlexpress]"
+  puts "rake update_db_server[server_name], example: rake update_db_server[\'.\\sqlexpress\']"
   puts "looking....\n\n"
 
   output = `sqlcmd -Lc`
   puts "here are your db servers and the rake command to update your connection strings:\n\n"
   output.each_line do |line|
-    puts "rake update_db_server[#{line.strip}]" if line.strip != ""
+    puts "rake update_db_server[\'#{line.strip}\']" if line.strip != ""
   end
+
+  puts "\nRun the command exactly as it is displayed above, including single quotes around the server name"
 end
 
 desc "updates all database connection string server values to the value specified, example: rake update_db_server[./sqlexpress]"
@@ -230,11 +232,13 @@ task :update_db_server, [:new_value] => :rake_dot_net_initialize do |t, args|
     "#{ @test_project }/App.config",
     "#{ @ui_project }/App.config"
   ].each do |file|
-    puts "updating connection string in: #{ file }"
-    content = File.open(file).read
-    content.gsub!("data source=#{ @database_server };", "data source=#{ args[:new_value] };")
-    File.open(file, "w") { |f| f.write(content) }
-    puts "done"
+    if File.exist? file
+      puts "updating connection string in: #{ file }"
+      content = File.open(file).read
+      content.gsub!("data source=#{ @database_server };", "data source=#{ args[:new_value] };")
+      File.open(file, "w") { |f| f.write(content) }
+      puts "done"
+    end
   end
 
   puts "updating dev.yml"

--- a/Sample Apps/Crib/Rakefile.rb
+++ b/Sample Apps/Crib/Rakefile.rb
@@ -139,14 +139,16 @@ task :list_db_servers => :rake_dot_net_initialize do
   puts "scanning the network for db servers (this may take a while)"
   puts "if you already know what database server you want to connect to,"
   puts "you can change your connection strings in the application by running the command:"
-  puts "rake update_db_server[server_name], example: rake update_db_server[.\\sqlexpress]"
+  puts "rake update_db_server[server_name], example: rake update_db_server[\'.\\sqlexpress\']"
   puts "looking....\n\n"
 
   output = `sqlcmd -Lc`
   puts "here are your db servers and the rake command to update your connection strings:\n\n"
   output.each_line do |line|
-    puts "rake update_db_server[#{line.strip}]" if line.strip != ""
+    puts "rake update_db_server[\'#{line.strip}\']" if line.strip != ""
   end
+
+  puts "\nRun the command exactly as it is displayed above, including single quotes around the server name"
 end
 
 desc "updates all database connection string server values to the value specified, example: rake update_db_server[./sqlexpress]"
@@ -157,11 +159,13 @@ task :update_db_server, [:new_value] => :rake_dot_net_initialize do |t, args|
     "#{ @mvc_project_directory }/Web.config",
     "#{ @test_project }/App.config"
   ].each do |file|
-    puts "updating connection string in: #{ file }"
-    content = File.open(file).read
-    content.gsub!("data source=#{ @database_server };", "data source=#{ args[:new_value] };")
-    File.open(file, "w") { |f| f.write(content) }
-    puts "done"
+    if File.exist? file
+      puts "updating connection string in: #{ file }"
+      content = File.open(file).read
+      content.gsub!("data source=#{ @database_server };", "data source=#{ args[:new_value] };")
+      File.open(file, "w") { |f| f.write(content) }
+      puts "done"
+    end
   end
 
   puts "updating dev.yml"

--- a/Sample Apps/DynamicBlog/Rakefile.rb
+++ b/Sample Apps/DynamicBlog/Rakefile.rb
@@ -138,14 +138,16 @@ task :list_db_servers => :rake_dot_net_initialize do
   puts "scanning the network for db servers (this may take a while)"
   puts "if you already know what database server you want to connect to,"
   puts "you can change your connection strings in the application by running the command:"
-  puts "rake update_db_server[server_name], example: rake update_db_server[.\\sqlexpress]"
+  puts "rake update_db_server[server_name], example: rake update_db_server[\'.\\sqlexpress\']"
   puts "looking....\n\n"
 
   output = `sqlcmd -Lc`
   puts "here are your db servers and the rake command to update your connection strings:\n\n"
   output.each_line do |line|
-    puts "rake update_db_server[#{line.strip}]" if line.strip != ""
+    puts "rake update_db_server[\'#{line.strip}\']" if line.strip != ""
   end
+
+  puts "\nRun the command exactly as it is displayed above, including single quotes around the server name"
 end
 
 desc "updates all database connection string server values to the value specified, example: rake update_db_server[./sqlexpress]"
@@ -156,11 +158,13 @@ task :update_db_server, [:new_value] => :rake_dot_net_initialize do |t, args|
     "#{ @mvc_project_directory }/Web.config",
     "#{ @test_project }/App.config"
   ].each do |file|
-    puts "updating connection string in: #{ file }"
-    content = File.open(file).read
-    content.gsub!("data source=#{ @database_server };", "data source=#{ args[:new_value] };")
-    File.open(file, "w") { |f| f.write(content) }
-    puts "done"
+    if File.exist? file
+      puts "updating connection string in: #{ file }"
+      content = File.open(file).read
+      content.gsub!("data source=#{ @database_server };", "data source=#{ args[:new_value] };")
+      File.open(file, "w") { |f| f.write(content) }
+      puts "done"
+    end
   end
 
   puts "updating dev.yml"

--- a/Sample Apps/Peeps/Rakefile.rb
+++ b/Sample Apps/Peeps/Rakefile.rb
@@ -138,14 +138,16 @@ task :list_db_servers => :rake_dot_net_initialize do
   puts "scanning the network for db servers (this may take a while)"
   puts "if you already know what database server you want to connect to,"
   puts "you can change your connection strings in the application by running the command:"
-  puts "rake update_db_server[server_name], example: rake update_db_server[.\\sqlexpress]"
+  puts "rake update_db_server[server_name], example: rake update_db_server[\'.\\sqlexpress\']"
   puts "looking....\n\n"
 
   output = `sqlcmd -Lc`
   puts "here are your db servers and the rake command to update your connection strings:\n\n"
   output.each_line do |line|
-    puts "rake update_db_server[#{line.strip}]" if line.strip != ""
+    puts "rake update_db_server[\'#{line.strip}\']" if line.strip != ""
   end
+
+  puts "\nRun the command exactly as it is displayed above, including single quotes around the server name"
 end
 
 desc "updates all database connection string server values to the value specified, example: rake update_db_server[./sqlexpress]"
@@ -156,11 +158,13 @@ task :update_db_server, [:new_value] => :rake_dot_net_initialize do |t, args|
     "#{ @mvc_project_directory }/Web.config",
     "#{ @test_project }/App.config"
   ].each do |file|
-    puts "updating connection string in: #{ file }"
-    content = File.open(file).read
-    content.gsub!("data source=#{ @database_server };", "data source=#{ args[:new_value] };")
-    File.open(file, "w") { |f| f.write(content) }
-    puts "done"
+    if File.exist? file
+      puts "updating connection string in: #{ file }"
+      content = File.open(file).read
+      content.gsub!("data source=#{ @database_server };", "data source=#{ args[:new_value] };")
+      File.open(file, "w") { |f| f.write(content) }
+      puts "done"
+    end
   end
 
   puts "updating dev.yml"

--- a/Sample Apps/TaskRabbits/Rakefile.rb
+++ b/Sample Apps/TaskRabbits/Rakefile.rb
@@ -138,14 +138,16 @@ task :list_db_servers => :rake_dot_net_initialize do
   puts "scanning the network for db servers (this may take a while)"
   puts "if you already know what database server you want to connect to,"
   puts "you can change your connection strings in the application by running the command:"
-  puts "rake update_db_server[server_name], example: rake update_db_server[.\\sqlexpress]"
+  puts "rake update_db_server[server_name], example: rake update_db_server[\'.\\sqlexpress\']"
   puts "looking....\n\n"
 
   output = `sqlcmd -Lc`
   puts "here are your db servers and the rake command to update your connection strings:\n\n"
   output.each_line do |line|
-    puts "rake update_db_server[#{line.strip}]" if line.strip != ""
+    puts "rake update_db_server[\'#{line.strip}\']" if line.strip != ""
   end
+
+  puts "\nRun the command exactly as it is displayed above, including single quotes around the server name"
 end
 
 desc "updates all database connection string server values to the value specified, example: rake update_db_server[./sqlexpress]"
@@ -156,11 +158,13 @@ task :update_db_server, [:new_value] => :rake_dot_net_initialize do |t, args|
     "#{ @mvc_project_directory }/Web.config",
     "#{ @test_project }/App.config"
   ].each do |file|
-    puts "updating connection string in: #{ file }"
-    content = File.open(file).read
-    content.gsub!("data source=#{ @database_server };", "data source=#{ args[:new_value] };")
-    File.open(file, "w") { |f| f.write(content) }
-    puts "done"
+    if File.exist? file
+      puts "updating connection string in: #{ file }"
+      content = File.open(file).read
+      content.gsub!("data source=#{ @database_server };", "data source=#{ args[:new_value] };")
+      File.open(file, "w") { |f| f.write(content) }
+      puts "done"
+    end
   end
 
   puts "updating dev.yml"

--- a/Sample Apps/TodoApp/Rakefile.rb
+++ b/Sample Apps/TodoApp/Rakefile.rb
@@ -138,14 +138,16 @@ task :list_db_servers => :rake_dot_net_initialize do
   puts "scanning the network for db servers (this may take a while)"
   puts "if you already know what database server you want to connect to,"
   puts "you can change your connection strings in the application by running the command:"
-  puts "rake update_db_server[server_name], example: rake update_db_server[.\\sqlexpress]"
+  puts "rake update_db_server[server_name], example: rake update_db_server[\'.\\sqlexpress\']"
   puts "looking....\n\n"
 
   output = `sqlcmd -Lc`
   puts "here are your db servers and the rake command to update your connection strings:\n\n"
   output.each_line do |line|
-    puts "rake update_db_server[#{line.strip}]" if line.strip != ""
+    puts "rake update_db_server[\'#{line.strip}\']" if line.strip != ""
   end
+
+  puts "\nRun the command exactly as it is displayed above, including single quotes around the server name"
 end
 
 desc "updates all database connection string server values to the value specified, example: rake update_db_server[./sqlexpress]"
@@ -156,11 +158,13 @@ task :update_db_server, [:new_value] => :rake_dot_net_initialize do |t, args|
     "#{ @mvc_project_directory }/Web.config",
     "#{ @test_project }/App.config"
   ].each do |file|
-    puts "updating connection string in: #{ file }"
-    content = File.open(file).read
-    content.gsub!("data source=#{ @database_server };", "data source=#{ args[:new_value] };")
-    File.open(file, "w") { |f| f.write(content) }
-    puts "done"
+    if File.exist? file
+      puts "updating connection string in: #{ file }"
+      content = File.open(file).read
+      content.gsub!("data source=#{ @database_server };", "data source=#{ args[:new_value] };")
+      File.open(file, "w") { |f| f.write(content) }
+      puts "done"
+    end
   end
 
   puts "updating dev.yml"


### PR DESCRIPTION
Fixed rake list_db_servers and rake update_db_server[<server_name>] command in all Rakefiles.

rake list_db_servers -- now reports update_db_server commands
with single quotes in the server name and a note reminding the user to not
forget them.

rake update_db_server[<server_name>] -- now checks that a file exists
before updating the connection string in that file